### PR TITLE
Adding Quarterly Snapshots and 2017/01/01 (among others)

### DIFF
--- a/historic.html
+++ b/historic.html
@@ -18,21 +18,120 @@
     <div class="limiter">
 
         <div class="row2">
-            <h2 class="fancy">OSM QA tiles historic tilesets</h2>
-        </div>
+          <h2 class="fancy">OSM QA tiles: historic snapshots</h2>
 
-        <div class='keyline-all round'>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20060101.mbtiles">2006/01/01, 677 KB</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20070101.mbtiles">2007/01/01, 57.7 MB</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20080101.mbtiles">2008/01/01, 4.1 GB</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20090101.mbtiles">2009/01/01, 6.1 GB</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20100101.mbtiles">2010/01/01, 6.1 GB</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20110101.mbtiles">2011/01/01, 11.2 GB</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20120101.mbtiles">2012/01/01, 15.1 GB</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20130101.mbtiles">2013/01/01, 22.5 GB</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20140101.mbtiles">2014/01/01, 53 GB</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20150101.mbtiles">2015/01/01, 52.6 GB</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20160101.mbtiles">2016/01/01, 58 GB</a></div>
+          <p class="space-top4">Historic snapshots represent the map as it was on a specific date. These files do not contain full editing history, but instead represent each map object as it existed at a specic time in history.</p>
+
+          <h3>Quarterly Snapshots</h3>
+          <p class="space-top1">Generated from the <a target="_blank" class="link" href="//planet.openstreetmap.org/planet/full-history/">full history pbf</a> with the <span class="code">time-filter</span> command of the <a target="_blank" class="link"  href="//osmcode.org/osmium-tool">osmium tool</a>, snapshots of the map as it existed at the end of each quarter are made available below.</p>
+
+          <p class='note'>For annual snapshots, use the fourth quarter of each year. These represent the map on January 01, 00:00.</p>
+
+          <table class='prose table'>
+            <thead>
+              <tr>
+                <th></th>
+                <th>First Quarter</th>
+                <th>Second Quarter</th>
+                <th>Third Quarter</th>
+                <th>Fourth Quarter</th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <tr>
+                <th>2005</th>
+                <td><a href="#">2005/04/01, ##.# MB</a></td>
+                <td><a href="#">2005/07/01, ##.# MB</a></td>
+                <td><a href="#">2005/10/01, ##.# MB</a></td>
+                <td><a href="#">2006/01/01, ##.# MB</a></td>
+              </tr>
+              <tr>
+                <th>2006</th>
+                <td><a href="#">2006/04/01, ##.# MB</a></td>
+                <td><a href="#">2006/07/01, ##.# MB</a></td>
+                <td><a href="#">2006/10/01, ##.# MB</a></td>
+                <td><a href="#">2007/01/01, ##.# MB</a></td>
+              </tr>
+              <tr>
+                <th>2007</th>
+                <td><a href="#">2007/04/01, ##.# GB</a></td>
+                <td><a href="#">2007/07/01, ##.# GB</a></td>
+                <td><a href="#">2007/10/01, ##.# GB</a></td>
+                <td><a href="#">2008/01/01, ##.# GB</a></td>
+              </tr>
+              <tr>
+                <th>2008</th>
+                <td><a href="#">2008/04/01, ##.# GB</a></td>
+                <td><a href="#">2008/07/01, ##.# GB</a></td>
+                <td><a href="#">2008/10/01, ##.# GB</a></td>
+                <td><a href="#">2009/01/01, ##.# GB</a></td>
+              </tr>
+              <tr>
+                <th>2009</th>
+                <td><a href="#">2009/04/01, ##.# GB</a></td>
+                <td><a href="#">2009/07/01, ##.# GB</a></td>
+                <td><a href="#">2009/10/01, ##.# GB</a></td>
+                <td><a href="#">2010/01/01, ##.# GB</a></td>
+              </tr>
+              <tr>
+                <th>2010</th>
+                <td><a href="#">2010/04/01, ##.# GB</a></td>
+                <td><a href="#">2010/07/01, ##.# GB</a></td>
+                <td><a href="#">2010/10/01, ##.# GB</a></td>
+                <td><a href="#">2011/01/01, ##.# GB</a></td>
+              </tr>
+              <tr>
+                <th>2011</th>
+                <td><a href="#">2011/04/01, ##.# GB</a></td>
+                <td><a href="#">2011/07/01, ##.# GB</a></td>
+                <td><a href="#">2011/10/01, ##.# GB</a></td>
+                <td><a href="#">2012/01/01, ##.# GB</a></td>
+              </tr>
+              <tr>
+                <th>2012</th>
+                <td><a href="#">2012/04/01, ##.# GB</a></td>
+                <td><a href="#">2012/07/01, ##.# GB</a></td>
+                <td><a href="#">2012/10/01, ##.# GB</a></td>
+                <td><a href="#">2013/01/01, ##.# GB</a></td>
+              </tr>
+              <tr>
+                <th>2013</th>
+                <td><a href="#">2013/04/01, ##.# GB</a></td>
+                <td><a href="#">2013/07/01, ##.# GB</a></td>
+                <td><a href="#">2013/10/01, ##.# GB</a></td>
+                <td><a href="#">2014/01/01, ##.# GB</a></td>
+              </tr>
+              <tr>
+                <th>2014</th>
+                <td><a href="#">2014/04/01, ##.# GB</a></td>
+                <td><a href="#">2014/07/01, ##.# GB</a></td>
+                <td><a href="#">2014/10/01, ##.# GB</a></td>
+                <td><a href="#">2015/01/01, ##.# GB</a></td>
+              </tr>
+              <tr>
+                <th>2015</th>
+                <td><a href="#">2015/04/01, ##.# GB</a></td>
+                <td><a href="#">2015/07/01, ##.# GB</a></td>
+                <td><a href="#">2015/10/01, ##.# GB</a></td>
+                <td><a href="#">2016/01/01, ##.# GB</a></td>
+              </tr>
+              <tr>
+                <th>2016</th>
+                <td><a href="#">2016/04/01, ##.# GB</a></td>
+                <td><a href="#">2016/07/01, ##.# GB</a></td>
+                <td><a href="#">2016/10/01, ##.# GB</a></td>
+                <td><a href="#">2017/01/01, ##.# GB</a></td>
+              </tr>
+              <tr>
+                <th>2017</th>
+                <td><a href="#">2017/04/01, ##.# GB</a></td>
+                <td><a href="#">2017/07/01, ##.# GB</a></td>
+                <td><a href="#">2017/10/01, ##.# GB</a></td>
+                <td><a href="#"></a>2018/01/01, ? GB</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
     </div>
 

--- a/historic.html
+++ b/historic.html
@@ -17,15 +17,18 @@
 <body>
     <div class="limiter">
 
-        <div class="row2">
+        <div>
           <h2 class="fancy">OSM QA tiles: historic snapshots</h2>
 
-          <p class="space-top4">Historic snapshots represent the map as it was on a specific date. These files do not contain full editing history, but instead represent each map object as it existed at a specic time in history.</p>
+          <p class="space-top2">Historic snapshots represent the map as it was on a specific date. These files do not contain full editing history, but instead represent each map object as it existed at a specic time in history.</p>
 
           <h3>Quarterly Snapshots</h3>
           <p class="space-top1">Generated from the <a target="_blank" class="link" href="//planet.openstreetmap.org/planet/full-history/">full history pbf</a> with the <span class="code">time-filter</span> command of the <a target="_blank" class="link"  href="//osmcode.org/osmium-tool">osmium tool</a>, snapshots of the map as it existed at the end of each quarter are made available below.</p>
 
-          <p class='note'>For annual snapshots, use the fourth quarter of each year. These represent the map on January 01, 00:00.</p>
+          <p class='note space-bottom1'>For annual snapshots, use the fourth quarter of each year. These represent the map on January 01, 00:00.</p>
+        </div>
+
+        <div>
 
           <table class='prose table'>
             <thead>
@@ -41,24 +44,24 @@
             <tbody>
               <tr>
                 <th>2005</th>
-                <td><a href="#">2005/04/01, ##.# MB</a></td>
-                <td><a href="#">2005/07/01, ##.# MB</a></td>
-                <td><a href="#">2005/10/01, ##.# MB</a></td>
-                <td><a href="#">2006/01/01, ##.# MB</a></td>
+                <td> </a></td>
+                <td><a href="#">2005/07/01, 108 KB</a></td>
+                <td><a href="#">2005/10/01, 271 KB</a></td>
+                <td><a href="#">2006/01/01, 673 KB</a></td>
               </tr>
               <tr>
                 <th>2006</th>
-                <td><a href="#">2006/04/01, ##.# MB</a></td>
-                <td><a href="#">2006/07/01, ##.# MB</a></td>
-                <td><a href="#">2006/10/01, ##.# MB</a></td>
-                <td><a href="#">2007/01/01, ##.# MB</a></td>
+                <td><a href="#">2006/04/01, 2.6 MB</a></td>
+                <td><a href="#">2006/07/01, 6.4 MB</a></td>
+                <td><a href="#">2006/10/01, 21 MB</a></td>
+                <td><a href="#">2007/01/01, 58 MB</a></td>
               </tr>
               <tr>
                 <th>2007</th>
-                <td><a href="#">2007/04/01, ##.# GB</a></td>
-                <td><a href="#">2007/07/01, ##.# GB</a></td>
-                <td><a href="#">2007/10/01, ##.# GB</a></td>
-                <td><a href="#">2008/01/01, ##.# GB</a></td>
+                <td><a href="#">2007/04/01, 117 MB</a></td>
+                <td><a href="#">2007/07/01, 217 MB</a></td>
+                <td><a href="#">2007/10/01, 954 MB</a></td>
+                <td><a href="#">2008/01/01, 4.1 GB</a></td>
               </tr>
               <tr>
                 <th>2008</th>
@@ -128,10 +131,41 @@
                 <td><a href="#">2017/04/01, ##.# GB</a></td>
                 <td><a href="#">2017/07/01, ##.# GB</a></td>
                 <td><a href="#">2017/10/01, ##.# GB</a></td>
-                <td><a href="#"></a>2018/01/01, ? GB</td>
+                <td><a href="#"></a>2018/01/01 TBD</td>
               </tr>
             </tbody>
           </table>
+        </div>
+
+        <div>
+
+          <h3 class=space-top4>How were these generated?</h3>
+          <p class="space-top1">First, the data is extracted from the full planet history: </p>
+          <p class="space-left2 code">osmium time-filter --verbose --overwrite -o 2010-Q1.osm.pbf planet-history.osm.pbf 2010-04-01T00:00:00Z</p>
+
+          <p class="space-top1">Next, the pbf file was turned into geojson with minjur. Note: minjur was incorporated into the osmium tool as <span class="code">export</p>
+
+          <p class="space-left2 code">minjur --polygons --zoom=12 --nodes=dense 2010-Q1.osm.pbf</p>
+
+          <p class="space-top1">Finally, the output of the above command was piped into tippecanoe:
+
+            <p class="space-left2 code">| tippecanoe -f -pf -pk -ps -Z12 -z12 -d20 --no-tile-stats -b0 -l osm -n 2010-Q1 -o 2010-Q1-qa-tile.mbtiles</p>
+
+          <p class="space-top1"> The flags ensure the following <a target="_blank" href="//github.com/mapbox/tippecanoe">(from the tippecanoe documentation):</a> </p>
+
+            <p class="space-left2"><span style="float:left; width:175px;" class="code">-Z12 -z12 -d20</span> Only generate zoom 12, with the maximum detail available at that resolution.</p>
+
+            <p class="space-left2"><span style="float:left; width:175px;" class="code">-pf -pk -ps</span> Don't limit tiles by size or feature count; don't simplify lines.</p>
+
+            <p class="space-left2"><span style="float:left; width:175px;" class="code">-b0</span> No buffer on the tile edges from which to duplicate next-door features.</p>
+
+            <p class="space-left2"><span style="float:left; width:175px;" class="code">--no-tile-stats</span>Don't generate statistics for object attributes. (Saves time and memory).</p>
+
+            <p class="space-left2"><span style="float:left; width:175px;" class="code">-l osm -n 2010-Q1</span>Name the layer "osm" and the tileset "2010-Q1".</p>
+
+
+          <br><br><br><hr><br>
+
         </div>
     </div>
 

--- a/historic.html
+++ b/historic.html
@@ -20,12 +20,19 @@
         <div>
           <h2 class="fancy">OSM QA tiles: historic snapshots</h2>
 
-          <p class="space-top2">Historic snapshots represent the map as it was on a specific date. These files do not contain full editing history, but instead represent each map object as it existed at a specic time in history.</p>
+          <p class="space-top2">Historic snapshots represent the map as it was on a specific date. These files do not contain the full editing history, but instead represent each map object as it existed at a specic time in history.</p>
 
           <h3>Quarterly Snapshots</h3>
+          <nav class='space-top1'>
+            <div class='inline-block pill space-top1'>
+              <a href='#' class='button'>Quarterly Snapshots</a>
+              <a href='#instructions' class='button stroke'>How were these tiles generated?</a>
+              <a href='#previous_generation' class='button stroke'>Previous Generation Annual Snapshots</a>
+            </div>
+          </nav>
           <p class="space-top1">Generated from the <a target="_blank" class="link" href="//planet.openstreetmap.org/planet/full-history/">full history pbf</a> with the <span class="code">time-filter</span> command of the <a target="_blank" class="link"  href="//osmcode.org/osmium-tool">osmium tool</a>, snapshots of the map as it existed at the end of each quarter are made available below.</p>
 
-          <p class='note space-bottom1'>For annual snapshots, use the fourth quarter of each year. These represent the map at December 31, 23:59.</p>
+          <p class='note space-bottom1'>For <strong>annual snapshots</strong>, use the fourth quarter of each year. These represent the map on December 31 at 23:59.</p>
         </div>
 
         <div>
@@ -65,52 +72,52 @@
               </tr>
               <tr>
                 <th>2008</th>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q1-qa-tiles.mbtiles">2008/04/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q2-qa-tiles.mbtiles">2008/07/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q3-qa-tiles.mbtiles">2008/10/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q4-qa-tiles.mbtiles">2009/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q1-qa-tiles.mbtiles">2008/04/01, 5.3 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q2-qa-tiles.mbtiles">2008/07/01, 5.6 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q3-qa-tiles.mbtiles">2008/10/01, 5.8 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q4-qa-tiles.mbtiles">2009/01/01, 6.0 GB</a></td>
               </tr>
               <tr>
                 <th>2009</th>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q1-qa-tiles.mbtiles">2009/04/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q2-qa-tiles.mbtiles">2009/07/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q3-qa-tiles.mbtiles">2009/10/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q4-qa-tiles.mbtiles">2010/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q1-qa-tiles.mbtiles">2009/04/01, 6.5 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q2-qa-tiles.mbtiles">2009/07/01, 7.0 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q3-qa-tiles.mbtiles">2009/10/01, 6.7 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q4-qa-tiles.mbtiles">2010/01/01, 5.4 GB</a></td>
               </tr>
               <tr>
                 <th>2010</th>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q1-qa-tiles.mbtiles">2010/04/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q2-qa-tiles.mbtiles">2010/07/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q3-qa-tiles.mbtiles">2010/10/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q4-qa-tiles.mbtiles">2011/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q1-qa-tiles.mbtiles">2010/04/01, 5.7 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q2-qa-tiles.mbtiles">2010/07/01, 6.4 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q3-qa-tiles.mbtiles">2010/10/01, 7.2 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q4-qa-tiles.mbtiles">2011/01/01, 8.1 GB</a></td>
               </tr>
               <tr>
                 <th>2011</th>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q1-qa-tiles.mbtiles">2011/04/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q2-qa-tiles.mbtiles">2011/07/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q3-qa-tiles.mbtiles">2011/10/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q4-qa-tiles.mbtiles">2012/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q1-qa-tiles.mbtiles">2011/04/01, 8.2 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q2-qa-tiles.mbtiles">2011/07/01, 8.9 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q3-qa-tiles.mbtiles">2011/10/01, 9.5 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q4-qa-tiles.mbtiles">2012/01/01, 10.2 GB</a></td>
               </tr>
               <tr>
                 <th>2012</th>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q1-qa-tiles.mbtiles">2012/04/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q2-qa-tiles.mbtiles">2012/07/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q3-qa-tiles.mbtiles">2012/10/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q4-qa-tiles.mbtiles">2013/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q1-qa-tiles.mbtiles">2012/04/01, 11.8 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q2-qa-tiles.mbtiles">2012/07/01, 12.5 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q3-qa-tiles.mbtiles">2012/10/01, 13.4 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q4-qa-tiles.mbtiles">2013/01/01, 14.2 GB</a></td>
               </tr>
               <tr>
                 <th>2013</th>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q1-qa-tiles.mbtiles">2013/04/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q2-qa-tiles.mbtiles">2013/07/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q3-qa-tiles.mbtiles">2013/10/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q4-qa-tiles.mbtiles">2014/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q1-qa-tiles.mbtiles">2013/04/01, 15.1 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q2-qa-tiles.mbtiles">2013/07/01, 15.9 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q3-qa-tiles.mbtiles">2013/10/01, 16.6 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q4-qa-tiles.mbtiles">2014/01/01, 17.2 GB</a></td>
               </tr>
               <tr>
                 <th>2014</th>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q1-qa-tiles.mbtiles">2014/04/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q2-qa-tiles.mbtiles">2014/07/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q3-qa-tiles.mbtiles">2014/10/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q4-qa-tiles.mbtiles">2015/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q1-qa-tiles.mbtiles">2014/04/01, 18.2 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q2-qa-tiles.mbtiles">2014/07/01, 19.3 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q3-qa-tiles.mbtiles">2014/10/01, 20.1 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q4-qa-tiles.mbtiles">2015/01/01, 21.0 GB</a></td>
               </tr>
               <tr>
                 <th>2015</th>
@@ -121,16 +128,16 @@
               </tr>
               <tr>
                 <th>2016</th>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q1-qa-tiles.mbtiles">2016/04/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q2-qa-tiles.mbtiles">2016/07/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q3-qa-tiles.mbtiles">2016/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q1-qa-tiles.mbtiles">2016/04/01, 25.2 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q2-qa-tiles.mbtiles">2016/07/01, 26.2 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q3-qa-tiles.mbtiles">2016/10/01, 27.0 GB</a></td>
                 <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q4-qa-tiles.mbtiles">2017/01/01, 27.8 GB</a></td>
               </tr>
               <tr>
                 <th>2017</th>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2017-Q1-qa-tiles.mbtiles">2017/04/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2017-Q2-qa-tiles.mbtiles">2017/07/01, ##.# GB</a></td>
-                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2017-Q3-qa-tiles.mbtiles">2017/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2017-Q1-qa-tiles.mbtiles">2017/04/01, 28.8 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2017-Q2-qa-tiles.mbtiles">2017/07/01, 29.7 GB</a></td>
+                <td><a href="#"></a>2017/10/01 TBD</a></td>
                 <td><a href="#"></a>2018/01/01 TBD</td>
               </tr>
             </tbody>
@@ -139,7 +146,14 @@
 
         <div>
 
-          <h3 class=space-top4>How were these generated?</h3>
+          <h3 id="instructions" class=space-top4>How were these generated?</h3>
+          <nav class='space-top1'>
+            <div class='inline-block pill space-top1'>
+              <a href='#' class='button stroke'>Quarterly Snapshots</a>
+              <a href='#instructions' class='button'>How were these tiles generated?</a>
+              <a href='#previous_generation' class='button stroke'>Previous Generation Annual Snapshots</a>
+            </div>
+          </nav>
           <p class="space-top1">First, the data is extracted from the full planet history: </p>
           <p class="space-left2 code">osmium time-filter --verbose --overwrite -o 2010-Q1.osm.pbf planet-history.osm.pbf 2010-04-01T00:00:00Z</p>
 
@@ -168,7 +182,14 @@
         </div>
         <div>
 
-          <h3 class=space-top4>Previous Generation Annual Snapshots</h3>
+          <h3 id="previous_generation" class=space-top4>Previous Generation Annual Snapshots</h3>
+          <nav class='space-top1'>
+            <div class='inline-block pill space-top1'>
+              <a href='#' class='button stroke'>Quarterly Snapshots</a>
+              <a href='#instructions' class='button stroke'>How were these tiles generated?</a>
+              <a href='#previous_generation' class='button'>Previous Generation Annual Snapshots</a>
+            </div>
+          </nav>
           <p class="space-top1">Before November 2017, annual osm-qa-tile snapshots were made available on
             this page. For consistency, these files are still available below, but users are cautioned to read the
             following description.</p>

--- a/historic.html
+++ b/historic.html
@@ -25,7 +25,7 @@
           <h3>Quarterly Snapshots</h3>
           <p class="space-top1">Generated from the <a target="_blank" class="link" href="//planet.openstreetmap.org/planet/full-history/">full history pbf</a> with the <span class="code">time-filter</span> command of the <a target="_blank" class="link"  href="//osmcode.org/osmium-tool">osmium tool</a>, snapshots of the map as it existed at the end of each quarter are made available below.</p>
 
-          <p class='note space-bottom1'>For annual snapshots, use the fourth quarter of each year. These represent the map on January 01, 00:00.</p>
+          <p class='note space-bottom1'>For annual snapshots, use the fourth quarter of each year. These represent the map at December 31, 23:59.</p>
         </div>
 
         <div>
@@ -45,92 +45,92 @@
               <tr>
                 <th>2005</th>
                 <td> </a></td>
-                <td><a href="#">2005/07/01, 108 KB</a></td>
-                <td><a href="#">2005/10/01, 271 KB</a></td>
-                <td><a href="#">2006/01/01, 673 KB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2005-Q2-qa-tiles.mbtiles">2005/07/01, 108 KB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2005-Q3-qa-tiles.mbtiles">2005/10/01, 271 KB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2005-Q4-qa-tiles.mbtiles">2006/01/01, 673 KB</a></td>
               </tr>
               <tr>
                 <th>2006</th>
-                <td><a href="#">2006/04/01, 2.6 MB</a></td>
-                <td><a href="#">2006/07/01, 6.4 MB</a></td>
-                <td><a href="#">2006/10/01, 21 MB</a></td>
-                <td><a href="#">2007/01/01, 58 MB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2006-Q1-qa-tiles.mbtiles">2006/04/01, 2.6 MB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2006-Q2-qa-tiles.mbtiles">2006/07/01, 6.4 MB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2006-Q3-qa-tiles.mbtiles">2006/10/01, 21 MB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2006-Q4-qa-tiles.mbtiles">2007/01/01, 58 MB</a></td>
               </tr>
               <tr>
                 <th>2007</th>
-                <td><a href="#">2007/04/01, 117 MB</a></td>
-                <td><a href="#">2007/07/01, 217 MB</a></td>
-                <td><a href="#">2007/10/01, 954 MB</a></td>
-                <td><a href="#">2008/01/01, 4.1 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2007-Q1-qa-tiles.mbtiles">2007/04/01, 117 MB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2007-Q2-qa-tiles.mbtiles">2007/07/01, 217 MB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2007-Q3-qa-tiles.mbtiles">2007/10/01, 954 MB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2007-Q4-qa-tiles.mbtiles">2008/01/01, 4.1 GB</a></td>
               </tr>
               <tr>
                 <th>2008</th>
-                <td><a href="#">2008/04/01, ##.# GB</a></td>
-                <td><a href="#">2008/07/01, ##.# GB</a></td>
-                <td><a href="#">2008/10/01, ##.# GB</a></td>
-                <td><a href="#">2009/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q1-qa-tiles.mbtiles">2008/04/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q2-qa-tiles.mbtiles">2008/07/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q3-qa-tiles.mbtiles">2008/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2008-Q4-qa-tiles.mbtiles">2009/01/01, ##.# GB</a></td>
               </tr>
               <tr>
                 <th>2009</th>
-                <td><a href="#">2009/04/01, ##.# GB</a></td>
-                <td><a href="#">2009/07/01, ##.# GB</a></td>
-                <td><a href="#">2009/10/01, ##.# GB</a></td>
-                <td><a href="#">2010/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q1-qa-tiles.mbtiles">2009/04/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q2-qa-tiles.mbtiles">2009/07/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q3-qa-tiles.mbtiles">2009/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2009-Q4-qa-tiles.mbtiles">2010/01/01, ##.# GB</a></td>
               </tr>
               <tr>
                 <th>2010</th>
-                <td><a href="#">2010/04/01, ##.# GB</a></td>
-                <td><a href="#">2010/07/01, ##.# GB</a></td>
-                <td><a href="#">2010/10/01, ##.# GB</a></td>
-                <td><a href="#">2011/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q1-qa-tiles.mbtiles">2010/04/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q2-qa-tiles.mbtiles">2010/07/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q3-qa-tiles.mbtiles">2010/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2010-Q4-qa-tiles.mbtiles">2011/01/01, ##.# GB</a></td>
               </tr>
               <tr>
                 <th>2011</th>
-                <td><a href="#">2011/04/01, ##.# GB</a></td>
-                <td><a href="#">2011/07/01, ##.# GB</a></td>
-                <td><a href="#">2011/10/01, ##.# GB</a></td>
-                <td><a href="#">2012/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q1-qa-tiles.mbtiles">2011/04/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q2-qa-tiles.mbtiles">2011/07/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q3-qa-tiles.mbtiles">2011/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2011-Q4-qa-tiles.mbtiles">2012/01/01, ##.# GB</a></td>
               </tr>
               <tr>
                 <th>2012</th>
-                <td><a href="#">2012/04/01, ##.# GB</a></td>
-                <td><a href="#">2012/07/01, ##.# GB</a></td>
-                <td><a href="#">2012/10/01, ##.# GB</a></td>
-                <td><a href="#">2013/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q1-qa-tiles.mbtiles">2012/04/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q2-qa-tiles.mbtiles">2012/07/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q3-qa-tiles.mbtiles">2012/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2012-Q4-qa-tiles.mbtiles">2013/01/01, ##.# GB</a></td>
               </tr>
               <tr>
                 <th>2013</th>
-                <td><a href="#">2013/04/01, ##.# GB</a></td>
-                <td><a href="#">2013/07/01, ##.# GB</a></td>
-                <td><a href="#">2013/10/01, ##.# GB</a></td>
-                <td><a href="#">2014/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q1-qa-tiles.mbtiles">2013/04/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q2-qa-tiles.mbtiles">2013/07/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q3-qa-tiles.mbtiles">2013/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2013-Q4-qa-tiles.mbtiles">2014/01/01, ##.# GB</a></td>
               </tr>
               <tr>
                 <th>2014</th>
-                <td><a href="#">2014/04/01, ##.# GB</a></td>
-                <td><a href="#">2014/07/01, ##.# GB</a></td>
-                <td><a href="#">2014/10/01, ##.# GB</a></td>
-                <td><a href="#">2015/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q1-qa-tiles.mbtiles">2014/04/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q2-qa-tiles.mbtiles">2014/07/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q3-qa-tiles.mbtiles">2014/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2014-Q4-qa-tiles.mbtiles">2015/01/01, ##.# GB</a></td>
               </tr>
               <tr>
                 <th>2015</th>
-                <td><a href="#">2015/04/01, ##.# GB</a></td>
-                <td><a href="#">2015/07/01, ##.# GB</a></td>
-                <td><a href="#">2015/10/01, ##.# GB</a></td>
-                <td><a href="#">2016/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2015-Q1-qa-tiles.mbtiles">2015/04/01, 20.4 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2015-Q2-qa-tiles.mbtiles">2015/07/01, 22.8 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2015-Q3-qa-tiles.mbtiles">2015/10/01, 23.5 GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2015-Q4-qa-tiles.mbtiles">2016/01/01, 24.3 GB</a></td>
               </tr>
               <tr>
                 <th>2016</th>
-                <td><a href="#">2016/04/01, ##.# GB</a></td>
-                <td><a href="#">2016/07/01, ##.# GB</a></td>
-                <td><a href="#">2016/10/01, ##.# GB</a></td>
-                <td><a href="#">2017/01/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q1-qa-tiles.mbtiles">2016/04/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q2-qa-tiles.mbtiles">2016/07/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q3-qa-tiles.mbtiles">2016/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2016-Q4-qa-tiles.mbtiles">2017/01/01, 27.8 GB</a></td>
               </tr>
               <tr>
                 <th>2017</th>
-                <td><a href="#">2017/04/01, ##.# GB</a></td>
-                <td><a href="#">2017/07/01, ##.# GB</a></td>
-                <td><a href="#">2017/10/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2017-Q1-qa-tiles.mbtiles">2017/04/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2017-Q2-qa-tiles.mbtiles">2017/07/01, ##.# GB</a></td>
+                <td><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/2017-Q3-qa-tiles.mbtiles">2017/10/01, ##.# GB</a></td>
                 <td><a href="#"></a>2018/01/01 TBD</td>
               </tr>
             </tbody>
@@ -163,10 +163,42 @@
 
             <p class="space-left2"><span style="float:left; width:175px;" class="code">-l osm -n 2010-Q1</span>Name the layer "osm" and the tileset "2010-Q1".</p>
 
+          <hr><br>
+
+        </div>
+        <div>
+
+          <h3 class=space-top4>Previous Generation Annual Snapshots</h3>
+          <p class="space-top1">Before November 2017, annual osm-qa-tile snapshots were made available on
+            this page. For consistency, these files are still available below, but users are cautioned to read the
+            following description.</p>
+
+          <p class="note space-top1">These snapshots include multipolygon representations of objects
+            where possible from the <code>minjur-mp</code> command. This results in many objects being duplicated and existing as both LineStrings, MultiLineStrings, and/or MultiPolygons.
+            This can be seen in the dramatic file size increases after 2012. Simply counting or aggregating feature and/or user counts in these tiles
+            will yield overly inflated numbers because some objects are duplicated over many tiles (such as polygons representing administrative boundaries).
+          </p>
+
+          <div class='keyline-all round'>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20060101.mbtiles">2006/01/01, 677 KB</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20070101.mbtiles">2007/01/01, 57.7 MB</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20080101.mbtiles">2008/01/01, 4.1 GB</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20090101.mbtiles">2009/01/01, 6.1 GB</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20100101.mbtiles">2010/01/01, 6.1 GB</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20110101.mbtiles">2011/01/01, 11.2 GB</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20120101.mbtiles">2012/01/01, 15.1 GB</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20130101.mbtiles">2013/01/01, 22.5 GB</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20140101.mbtiles">2014/01/01, 53 GB</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20150101.mbtiles">2015/01/01, 52.6 GB</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://s3.amazonaws.com/mapbox/osm-qa-tiles/historic/planet-20160101.mbtiles">2016/01/01, 58 GB</a></div>
+        </div>
+
+
 
           <br><br><br><hr><br>
 
         </div>
+
     </div>
 
 </body>


### PR DESCRIPTION
Updating the historic.html page to include historical snapshots and newer files.

Keeping the previous annual snapshots, (but noting that they have many duplicated features due to minjur-mp when they were generated -- more information on the page).
