### PR TITLE
display last modified date of osm-qa-tiles planet file as tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,4 +133,11 @@ var map = L.mapbox.map('map', 'aaronlidman.b02452c3', {
     zoomControl: false
 }).setView([37.772292151125505, -122.40674436092377], 17);
 </script>
+<script type="text/javascript">
+fetch('https://s3.amazonaws.com/mapbox/osm-qa-tiles-production/latest.planet.mbtiles.gz', { method: 'HEAD' })
+.then(r => r.headers.get('Last-Modified'))
+.then(lmh => new Date(lmh)).then(lm =>
+  document.querySelector('#download .description').setAttribute('title', 'last modified: ' + lm.toUTCString())
+);
+</script>
 </html>


### PR DESCRIPTION
Makes a `HEAD` request to find out the latest modification date as reported by the HTTP headers from S3. This should at least partially address issue #6.

![selection_098](https://user-images.githubusercontent.com/1927298/44538189-ea725480-a700-11e8-9b95-b358f8c93e5a.png)

A similar approach could also be used to dynamically fetch and display the actual file size of the planet (and country extracts, see #7) files – instead of having a hardcoded file size (which is quickly outdated: now it shows `24.3 GB` while the actual file is mor like `33.7 GB` large). But for that to work the osm-qa-tiles would need to allow a CORS site to read the `Content-Length` header (by setting the [`Access-Control-Expose-Headers = Content-Lenght`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) header in the response). //cc @geohacker: Can you guys set that up on the S3 bucket? If yes, I can include that in this PR as well.
