### PR TITLE
Change s3 urls for hot-qa-tiles

### DIFF
--- a/country.html
+++ b/country.html
@@ -22,247 +22,247 @@
         </div>
 
         <div class='keyline-all round'>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/afghanistan.mbtiles.gz">afghanistan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/åland_islands.mbtiles.gz">åland islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/albania.mbtiles.gz">albania</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/algeria.mbtiles.gz">algeria</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/american_samoa.mbtiles.gz">american samoa</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/andorra.mbtiles.gz">andorra</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/angola.mbtiles.gz">angola</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/anguilla.mbtiles.gz">anguilla</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/antarctica.mbtiles.gz">antarctica</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/antigua_and_barbuda.mbtiles.gz">antigua and barbuda</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/argentina.mbtiles.gz">argentina</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/armenia.mbtiles.gz">armenia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/aruba.mbtiles.gz">aruba</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/ashmore_and_cartier_islands.mbtiles.gz">ashmore and cartier islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/australia.mbtiles.gz">australia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/australian_indian_ocean_territories.mbtiles.gz">australian indian ocean territories</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/austria.mbtiles.gz">austria</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/azerbaijan.mbtiles.gz">azerbaijan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/bahrain.mbtiles.gz">bahrain</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/bangladesh.mbtiles.gz">bangladesh</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/barbados.mbtiles.gz">barbados</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/belarus.mbtiles.gz">belarus</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/belgium.mbtiles.gz">belgium</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/belize.mbtiles.gz">belize</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/benin.mbtiles.gz">benin</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/bermuda.mbtiles.gz">bermuda</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/bhutan.mbtiles.gz">bhutan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/bolivia.mbtiles.gz">bolivia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/bosnia_and_herzegovina.mbtiles.gz">bosnia and herzegovina</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/botswana.mbtiles.gz">botswana</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/brazil.mbtiles.gz">brazil</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/british_indian_ocean_territory.mbtiles.gz">british indian ocean territory</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/british_virgin_islands.mbtiles.gz">british virgin islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/brunei.mbtiles.gz">brunei</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/bulgaria.mbtiles.gz">bulgaria</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/burkina_faso.mbtiles.gz">burkina faso</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/burundi.mbtiles.gz">burundi</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/cambodia.mbtiles.gz">cambodia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/cameroon.mbtiles.gz">cameroon</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/canada.mbtiles.gz">canada</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/cape_verde.mbtiles.gz">cape verde</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/cayman_islands.mbtiles.gz">cayman islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/central_african_republic.mbtiles.gz">central african republic</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/chad.mbtiles.gz">chad</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/chile.mbtiles.gz">chile</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/colombia.mbtiles.gz">colombia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/comoros.mbtiles.gz">comoros</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/cook_islands.mbtiles.gz">cook islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/costa_rica.mbtiles.gz">costa rica</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/croatia.mbtiles.gz">croatia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/cuba.mbtiles.gz">cuba</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/curaçao.mbtiles.gz">curaçao</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/cyprus.mbtiles.gz">cyprus</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/czech_republic.mbtiles.gz">czech republic</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/democratic_republic_of_the_congo.mbtiles.gz">democratic republic of the congo</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/denmark.mbtiles.gz">denmark</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/djibouti.mbtiles.gz">djibouti</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/dominica.mbtiles.gz">dominica</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/dominican_republic.mbtiles.gz">dominican republic</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/east_timor.mbtiles.gz">east timor</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/ecuador.mbtiles.gz">ecuador</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/egypt.mbtiles.gz">egypt</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/el_salvador.mbtiles.gz">el salvador</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/equatorial_guinea.mbtiles.gz">equatorial guinea</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/eritrea.mbtiles.gz">eritrea</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/estonia.mbtiles.gz">estonia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/eswatini.mbtiles.gz">eswatini</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/ethiopia.mbtiles.gz">ethiopia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/falkland_islands.mbtiles.gz">falkland islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/faroe_islands.mbtiles.gz">faroe islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/federated_states_of_micronesia.mbtiles.gz">federated states of micronesia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/fiji.mbtiles.gz">fiji</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/finland.mbtiles.gz">finland</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/france.mbtiles.gz">france</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/french_polynesia.mbtiles.gz">french polynesia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/french_southern_and_antarctic_lands.mbtiles.gz">french southern and antarctic lands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/gabon.mbtiles.gz">gabon</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/georgia.mbtiles.gz">georgia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/germany.mbtiles.gz">germany</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/ghana.mbtiles.gz">ghana</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/greece.mbtiles.gz">greece</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/greenland.mbtiles.gz">greenland</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/grenada.mbtiles.gz">grenada</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/guam.mbtiles.gz">guam</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/guatemala.mbtiles.gz">guatemala</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/guernsey.mbtiles.gz">guernsey</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/guinea.mbtiles.gz">guinea</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/guinea-bissau.mbtiles.gz">guinea-bissau</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/guyana.mbtiles.gz">guyana</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/haiti.mbtiles.gz">haiti</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/heard_island_and_mcdonald_islands.mbtiles.gz">heard island and mcdonald islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/honduras.mbtiles.gz">honduras</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/hong_kong.mbtiles.gz">hong kong</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/hungary.mbtiles.gz">hungary</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/iceland.mbtiles.gz">iceland</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/india.mbtiles.gz">india</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/indonesia.mbtiles.gz">indonesia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/iran.mbtiles.gz">iran</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/iraq.mbtiles.gz">iraq</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/ireland.mbtiles.gz">ireland</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/isle_of_man.mbtiles.gz">isle of man</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/israel.mbtiles.gz">israel</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/italy.mbtiles.gz">italy</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/ivory_coast.mbtiles.gz">ivory coast</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/jamaica.mbtiles.gz">jamaica</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/japan.mbtiles.gz">japan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/jersey.mbtiles.gz">jersey</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/jordan.mbtiles.gz">jordan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/kazakhstan.mbtiles.gz">kazakhstan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/kenya.mbtiles.gz">kenya</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/kiribati.mbtiles.gz">kiribati</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/kosovo.mbtiles.gz">kosovo</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/kuwait.mbtiles.gz">kuwait</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/kyrgyzstan.mbtiles.gz">kyrgyzstan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/laos.mbtiles.gz">laos</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/latvia.mbtiles.gz">latvia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/lebanon.mbtiles.gz">lebanon</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/lesotho.mbtiles.gz">lesotho</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/liberia.mbtiles.gz">liberia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/libya.mbtiles.gz">libya</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/liechtenstein.mbtiles.gz">liechtenstein</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/lithuania.mbtiles.gz">lithuania</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/luxembourg.mbtiles.gz">luxembourg</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/macau.mbtiles.gz">macau</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/madagascar.mbtiles.gz">madagascar</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/malawi.mbtiles.gz">malawi</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/malaysia.mbtiles.gz">malaysia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/maldives.mbtiles.gz">maldives</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/mali.mbtiles.gz">mali</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/malta.mbtiles.gz">malta</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/marshall_islands.mbtiles.gz">marshall islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/mauritania.mbtiles.gz">mauritania</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/mauritius.mbtiles.gz">mauritius</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/mexico.mbtiles.gz">mexico</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/moldova.mbtiles.gz">moldova</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/monaco.mbtiles.gz">monaco</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/mongolia.mbtiles.gz">mongolia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/montenegro.mbtiles.gz">montenegro</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/montserrat.mbtiles.gz">montserrat</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/morocco.mbtiles.gz">morocco</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/mozambique.mbtiles.gz">mozambique</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/myanmar.mbtiles.gz">myanmar</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/namibia.mbtiles.gz">namibia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/nauru.mbtiles.gz">nauru</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/nepal.mbtiles.gz">nepal</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/netherlands.mbtiles.gz">netherlands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/new_caledonia.mbtiles.gz">new caledonia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/new_zealand.mbtiles.gz">new zealand</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/nicaragua.mbtiles.gz">nicaragua</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/niger.mbtiles.gz">niger</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/nigeria.mbtiles.gz">nigeria</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/niue.mbtiles.gz">niue</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/norfolk_island.mbtiles.gz">norfolk island</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/north_korea.mbtiles.gz">north korea</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/northern_mariana_islands.mbtiles.gz">northern mariana islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/norway.mbtiles.gz">norway</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/oman.mbtiles.gz">oman</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/pakistan.mbtiles.gz">pakistan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/palau.mbtiles.gz">palau</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/palestine.mbtiles.gz">palestine</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/panama.mbtiles.gz">panama</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/papua_new_guinea.mbtiles.gz">papua new guinea</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/paraguay.mbtiles.gz">paraguay</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/people's_republic_of_china.mbtiles.gz">people's republic of china</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/peru.mbtiles.gz">peru</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/philippines.mbtiles.gz">philippines</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/pitcairn_islands.mbtiles.gz">pitcairn islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/poland.mbtiles.gz">poland</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/portugal.mbtiles.gz">portugal</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/puerto_rico.mbtiles.gz">puerto rico</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/qatar.mbtiles.gz">qatar</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/republic_of_macedonia.mbtiles.gz">republic of macedonia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/republic_of_the_congo.mbtiles.gz">republic of the congo</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/romania.mbtiles.gz">romania</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/russia.mbtiles.gz">russia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/rwanda.mbtiles.gz">rwanda</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/saint_helena.mbtiles.gz">saint helena</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/saint_kitts_and_nevis.mbtiles.gz">saint kitts and nevis</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/saint_lucia.mbtiles.gz">saint lucia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/saint_martin.mbtiles.gz">saint martin</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/saint_pierre_and_miquelon.mbtiles.gz">saint pierre and miquelon</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/saint_vincent_and_the_grenadines.mbtiles.gz">saint vincent and the grenadines</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/saint-barthélemy.mbtiles.gz">saint-barthélemy</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/samoa.mbtiles.gz">samoa</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/san_marino.mbtiles.gz">san marino</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/saudi_arabia.mbtiles.gz">saudi arabia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/senegal.mbtiles.gz">senegal</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/serbia.mbtiles.gz">serbia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/seychelles.mbtiles.gz">seychelles</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/siachen_glacier.mbtiles.gz">siachen glacier</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/sierra_leone.mbtiles.gz">sierra leone</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/singapore.mbtiles.gz">singapore</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/sint_maarten.mbtiles.gz">sint maarten</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/slovakia.mbtiles.gz">slovakia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/slovenia.mbtiles.gz">slovenia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/solomon_islands.mbtiles.gz">solomon islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/somalia.mbtiles.gz">somalia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/somaliland.mbtiles.gz">somaliland</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/south_africa.mbtiles.gz">south africa</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/south_georgia_and_the_south_sandwich_islands.mbtiles.gz">south georgia and the south sandwich islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/south_korea.mbtiles.gz">south korea</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/south_sudan.mbtiles.gz">south sudan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/spain.mbtiles.gz">spain</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/sri_lanka.mbtiles.gz">sri lanka</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/sudan.mbtiles.gz">sudan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/suriname.mbtiles.gz">suriname</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/sweden.mbtiles.gz">sweden</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/switzerland.mbtiles.gz">switzerland</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/syria.mbtiles.gz">syria</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/são_tomé_and_príncipe.mbtiles.gz">são tomé and príncipe</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/taiwan.mbtiles.gz">taiwan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/tajikistan.mbtiles.gz">tajikistan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/tanzania.mbtiles.gz">tanzania</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/thailand.mbtiles.gz">thailand</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/the_bahamas.mbtiles.gz">the bahamas</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/the_gambia.mbtiles.gz">the gambia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/togo.mbtiles.gz">togo</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/tonga.mbtiles.gz">tonga</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/trinidad_and_tobago.mbtiles.gz">trinidad and tobago</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/tunisia.mbtiles.gz">tunisia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/turkey.mbtiles.gz">turkey</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/turkish_republic_of_northern_cyprus.mbtiles.gz">turkish republic of northern cyprus</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/turkmenistan.mbtiles.gz">turkmenistan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/turks_and_caicos_islands.mbtiles.gz">turks and caicos islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/uganda.mbtiles.gz">uganda</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/ukraine.mbtiles.gz">ukraine</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/united_arab_emirates.mbtiles.gz">united arab emirates</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/united_kingdom.mbtiles.gz">united kingdom</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/united_states_virgin_islands.mbtiles.gz">united states virgin islands</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/united_states_of_america.mbtiles.gz">united states of america</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/uruguay.mbtiles.gz">uruguay</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/uzbekistan.mbtiles.gz">uzbekistan</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/vanuatu.mbtiles.gz">vanuatu</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/vatican_city.mbtiles.gz">vatican city</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/venezuela.mbtiles.gz">venezuela</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/vietnam.mbtiles.gz">vietnam</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/wallis_and_futuna.mbtiles.gz">wallis and futuna</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/western_sahara.mbtiles.gz">western sahara</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/yemen.mbtiles.gz">yemen</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/zambia.mbtiles.gz">zambia</a></div>
-            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles.s3.amazonaws.com/latest.country/zimbabwe.mbtiles.gz">zimbabwe</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/afghanistan.mbtiles.gz">afghanistan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/åland_islands.mbtiles.gz">åland islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/albania.mbtiles.gz">albania</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/algeria.mbtiles.gz">algeria</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/american_samoa.mbtiles.gz">american samoa</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/andorra.mbtiles.gz">andorra</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/angola.mbtiles.gz">angola</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/anguilla.mbtiles.gz">anguilla</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/antarctica.mbtiles.gz">antarctica</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/antigua_and_barbuda.mbtiles.gz">antigua and barbuda</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/argentina.mbtiles.gz">argentina</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/armenia.mbtiles.gz">armenia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/aruba.mbtiles.gz">aruba</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/ashmore_and_cartier_islands.mbtiles.gz">ashmore and cartier islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/australia.mbtiles.gz">australia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/australian_indian_ocean_territories.mbtiles.gz">australian indian ocean territories</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/austria.mbtiles.gz">austria</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/azerbaijan.mbtiles.gz">azerbaijan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/bahrain.mbtiles.gz">bahrain</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/bangladesh.mbtiles.gz">bangladesh</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/barbados.mbtiles.gz">barbados</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/belarus.mbtiles.gz">belarus</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/belgium.mbtiles.gz">belgium</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/belize.mbtiles.gz">belize</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/benin.mbtiles.gz">benin</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/bermuda.mbtiles.gz">bermuda</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/bhutan.mbtiles.gz">bhutan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/bolivia.mbtiles.gz">bolivia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/bosnia_and_herzegovina.mbtiles.gz">bosnia and herzegovina</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/botswana.mbtiles.gz">botswana</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/brazil.mbtiles.gz">brazil</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/british_indian_ocean_territory.mbtiles.gz">british indian ocean territory</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/british_virgin_islands.mbtiles.gz">british virgin islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/brunei.mbtiles.gz">brunei</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/bulgaria.mbtiles.gz">bulgaria</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/burkina_faso.mbtiles.gz">burkina faso</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/burundi.mbtiles.gz">burundi</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/cambodia.mbtiles.gz">cambodia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/cameroon.mbtiles.gz">cameroon</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/canada.mbtiles.gz">canada</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/cape_verde.mbtiles.gz">cape verde</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/cayman_islands.mbtiles.gz">cayman islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/central_african_republic.mbtiles.gz">central african republic</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/chad.mbtiles.gz">chad</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/chile.mbtiles.gz">chile</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/colombia.mbtiles.gz">colombia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/comoros.mbtiles.gz">comoros</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/cook_islands.mbtiles.gz">cook islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/costa_rica.mbtiles.gz">costa rica</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/croatia.mbtiles.gz">croatia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/cuba.mbtiles.gz">cuba</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/curaçao.mbtiles.gz">curaçao</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/cyprus.mbtiles.gz">cyprus</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/czech_republic.mbtiles.gz">czech republic</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/democratic_republic_of_the_congo.mbtiles.gz">democratic republic of the congo</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/denmark.mbtiles.gz">denmark</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/djibouti.mbtiles.gz">djibouti</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/dominica.mbtiles.gz">dominica</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/dominican_republic.mbtiles.gz">dominican republic</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/east_timor.mbtiles.gz">east timor</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/ecuador.mbtiles.gz">ecuador</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/egypt.mbtiles.gz">egypt</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/el_salvador.mbtiles.gz">el salvador</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/equatorial_guinea.mbtiles.gz">equatorial guinea</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/eritrea.mbtiles.gz">eritrea</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/estonia.mbtiles.gz">estonia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/eswatini.mbtiles.gz">eswatini</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/ethiopia.mbtiles.gz">ethiopia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/falkland_islands.mbtiles.gz">falkland islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/faroe_islands.mbtiles.gz">faroe islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/federated_states_of_micronesia.mbtiles.gz">federated states of micronesia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/fiji.mbtiles.gz">fiji</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/finland.mbtiles.gz">finland</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/france.mbtiles.gz">france</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/french_polynesia.mbtiles.gz">french polynesia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/french_southern_and_antarctic_lands.mbtiles.gz">french southern and antarctic lands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/gabon.mbtiles.gz">gabon</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/georgia.mbtiles.gz">georgia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/germany.mbtiles.gz">germany</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/ghana.mbtiles.gz">ghana</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/greece.mbtiles.gz">greece</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/greenland.mbtiles.gz">greenland</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/grenada.mbtiles.gz">grenada</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/guam.mbtiles.gz">guam</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/guatemala.mbtiles.gz">guatemala</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/guernsey.mbtiles.gz">guernsey</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/guinea.mbtiles.gz">guinea</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/guinea-bissau.mbtiles.gz">guinea-bissau</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/guyana.mbtiles.gz">guyana</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/haiti.mbtiles.gz">haiti</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/heard_island_and_mcdonald_islands.mbtiles.gz">heard island and mcdonald islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/honduras.mbtiles.gz">honduras</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/hong_kong.mbtiles.gz">hong kong</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/hungary.mbtiles.gz">hungary</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/iceland.mbtiles.gz">iceland</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/india.mbtiles.gz">india</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/indonesia.mbtiles.gz">indonesia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/iran.mbtiles.gz">iran</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/iraq.mbtiles.gz">iraq</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/ireland.mbtiles.gz">ireland</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/isle_of_man.mbtiles.gz">isle of man</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/israel.mbtiles.gz">israel</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/italy.mbtiles.gz">italy</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/ivory_coast.mbtiles.gz">ivory coast</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/jamaica.mbtiles.gz">jamaica</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/japan.mbtiles.gz">japan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/jersey.mbtiles.gz">jersey</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/jordan.mbtiles.gz">jordan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/kazakhstan.mbtiles.gz">kazakhstan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/kenya.mbtiles.gz">kenya</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/kiribati.mbtiles.gz">kiribati</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/kosovo.mbtiles.gz">kosovo</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/kuwait.mbtiles.gz">kuwait</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/kyrgyzstan.mbtiles.gz">kyrgyzstan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/laos.mbtiles.gz">laos</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/latvia.mbtiles.gz">latvia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/lebanon.mbtiles.gz">lebanon</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/lesotho.mbtiles.gz">lesotho</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/liberia.mbtiles.gz">liberia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/libya.mbtiles.gz">libya</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/liechtenstein.mbtiles.gz">liechtenstein</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/lithuania.mbtiles.gz">lithuania</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/luxembourg.mbtiles.gz">luxembourg</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/macau.mbtiles.gz">macau</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/madagascar.mbtiles.gz">madagascar</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/malawi.mbtiles.gz">malawi</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/malaysia.mbtiles.gz">malaysia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/maldives.mbtiles.gz">maldives</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/mali.mbtiles.gz">mali</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/malta.mbtiles.gz">malta</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/marshall_islands.mbtiles.gz">marshall islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/mauritania.mbtiles.gz">mauritania</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/mauritius.mbtiles.gz">mauritius</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/mexico.mbtiles.gz">mexico</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/moldova.mbtiles.gz">moldova</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/monaco.mbtiles.gz">monaco</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/mongolia.mbtiles.gz">mongolia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/montenegro.mbtiles.gz">montenegro</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/montserrat.mbtiles.gz">montserrat</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/morocco.mbtiles.gz">morocco</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/mozambique.mbtiles.gz">mozambique</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/myanmar.mbtiles.gz">myanmar</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/namibia.mbtiles.gz">namibia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/nauru.mbtiles.gz">nauru</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/nepal.mbtiles.gz">nepal</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/netherlands.mbtiles.gz">netherlands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/new_caledonia.mbtiles.gz">new caledonia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/new_zealand.mbtiles.gz">new zealand</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/nicaragua.mbtiles.gz">nicaragua</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/niger.mbtiles.gz">niger</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/nigeria.mbtiles.gz">nigeria</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/niue.mbtiles.gz">niue</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/norfolk_island.mbtiles.gz">norfolk island</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/north_korea.mbtiles.gz">north korea</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/northern_mariana_islands.mbtiles.gz">northern mariana islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/norway.mbtiles.gz">norway</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/oman.mbtiles.gz">oman</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/pakistan.mbtiles.gz">pakistan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/palau.mbtiles.gz">palau</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/palestine.mbtiles.gz">palestine</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/panama.mbtiles.gz">panama</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/papua_new_guinea.mbtiles.gz">papua new guinea</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/paraguay.mbtiles.gz">paraguay</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/people's_republic_of_china.mbtiles.gz">people's republic of china</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/peru.mbtiles.gz">peru</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/philippines.mbtiles.gz">philippines</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/pitcairn_islands.mbtiles.gz">pitcairn islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/poland.mbtiles.gz">poland</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/portugal.mbtiles.gz">portugal</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/puerto_rico.mbtiles.gz">puerto rico</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/qatar.mbtiles.gz">qatar</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/republic_of_macedonia.mbtiles.gz">republic of macedonia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/republic_of_the_congo.mbtiles.gz">republic of the congo</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/romania.mbtiles.gz">romania</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/russia.mbtiles.gz">russia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/rwanda.mbtiles.gz">rwanda</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/saint_helena.mbtiles.gz">saint helena</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/saint_kitts_and_nevis.mbtiles.gz">saint kitts and nevis</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/saint_lucia.mbtiles.gz">saint lucia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/saint_martin.mbtiles.gz">saint martin</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/saint_pierre_and_miquelon.mbtiles.gz">saint pierre and miquelon</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/saint_vincent_and_the_grenadines.mbtiles.gz">saint vincent and the grenadines</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/saint-barthélemy.mbtiles.gz">saint-barthélemy</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/samoa.mbtiles.gz">samoa</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/san_marino.mbtiles.gz">san marino</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/saudi_arabia.mbtiles.gz">saudi arabia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/senegal.mbtiles.gz">senegal</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/serbia.mbtiles.gz">serbia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/seychelles.mbtiles.gz">seychelles</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/siachen_glacier.mbtiles.gz">siachen glacier</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/sierra_leone.mbtiles.gz">sierra leone</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/singapore.mbtiles.gz">singapore</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/sint_maarten.mbtiles.gz">sint maarten</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/slovakia.mbtiles.gz">slovakia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/slovenia.mbtiles.gz">slovenia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/solomon_islands.mbtiles.gz">solomon islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/somalia.mbtiles.gz">somalia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/somaliland.mbtiles.gz">somaliland</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/south_africa.mbtiles.gz">south africa</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/south_georgia_and_the_south_sandwich_islands.mbtiles.gz">south georgia and the south sandwich islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/south_korea.mbtiles.gz">south korea</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/south_sudan.mbtiles.gz">south sudan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/spain.mbtiles.gz">spain</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/sri_lanka.mbtiles.gz">sri lanka</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/sudan.mbtiles.gz">sudan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/suriname.mbtiles.gz">suriname</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/sweden.mbtiles.gz">sweden</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/switzerland.mbtiles.gz">switzerland</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/syria.mbtiles.gz">syria</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/são_tomé_and_príncipe.mbtiles.gz">são tomé and príncipe</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/taiwan.mbtiles.gz">taiwan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/tajikistan.mbtiles.gz">tajikistan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/tanzania.mbtiles.gz">tanzania</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/thailand.mbtiles.gz">thailand</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/the_bahamas.mbtiles.gz">the bahamas</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/the_gambia.mbtiles.gz">the gambia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/togo.mbtiles.gz">togo</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/tonga.mbtiles.gz">tonga</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/trinidad_and_tobago.mbtiles.gz">trinidad and tobago</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/tunisia.mbtiles.gz">tunisia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/turkey.mbtiles.gz">turkey</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/turkish_republic_of_northern_cyprus.mbtiles.gz">turkish republic of northern cyprus</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/turkmenistan.mbtiles.gz">turkmenistan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/turks_and_caicos_islands.mbtiles.gz">turks and caicos islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/uganda.mbtiles.gz">uganda</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/ukraine.mbtiles.gz">ukraine</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/united_arab_emirates.mbtiles.gz">united arab emirates</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/united_kingdom.mbtiles.gz">united kingdom</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/united_states_virgin_islands.mbtiles.gz">united states virgin islands</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/united_states_of_america.mbtiles.gz">united states of america</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/uruguay.mbtiles.gz">uruguay</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/uzbekistan.mbtiles.gz">uzbekistan</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/vanuatu.mbtiles.gz">vanuatu</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/vatican_city.mbtiles.gz">vatican city</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/venezuela.mbtiles.gz">venezuela</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/vietnam.mbtiles.gz">vietnam</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/wallis_and_futuna.mbtiles.gz">wallis and futuna</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/western_sahara.mbtiles.gz">western sahara</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/yemen.mbtiles.gz">yemen</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/zambia.mbtiles.gz">zambia</a></div>
+            <div class='pad1y pad2x keyline-bottom'><a href="https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.country/zimbabwe.mbtiles.gz">zimbabwe</a></div>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
             </div>
         </div>
         <div id='download' class='col7 center'>
-            <a href='https://hot-qa-tiles.s3.amazonaws.com/latest.planet.mbtiles.gz' class='button fill-dark'>
+            <a href='https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.planet.mbtiles.gz' class='button fill-dark'>
             <div class="label">DOWNLOAD PLANET (~36 GB)</div>
             <div class="description">updated weekly</div>
             <div class="updated"></div></a>
@@ -113,7 +113,7 @@
         </div>
     </div>
     <script type="text/javascript">
-      fetch('https://hot-qa-tiles.s3.amazonaws.com/latest.planet.mbtiles.gz', { method: 'HEAD' })
+      fetch('https://hot-qa-tiles-us-east-1.s3.amazonaws.com/latest.planet.mbtiles.gz', { method: 'HEAD' })
         .then(r => r.headers.get('Last-Modified'))
         .then(lmh => new Date(lmh)).then(lm =>
         document.querySelector('#download .updated').innerHTML = 'last modified: ' + lm.toUTCString());


### PR DESCRIPTION
We migrated the osm-tiles to a new s3 bucket, so the links will need to be updated. 